### PR TITLE
Fix light and contrast theme, remove unnecessary css selector

### DIFF
--- a/dist/catppuccin.user.css
+++ b/dist/catppuccin.user.css
@@ -17,14 +17,18 @@ domain("tech.lgbt"),
 domain("mastodon.social") {
 
 
-    :root:has(.theme-default-light) {
-        #mastodon(@lightFlavour, @accentColour);
-    }
-    
-    :root:has(.theme-default) {
+    .theme-default {
         #mastodon(@darkFlavour, @accentColour);
     }
-        
+
+    .theme-mastodon-light {
+        #mastodon(@lightFlavour, @accentColour);
+    }
+
+    .theme-contrast {
+        #mastodon(@darkFlavour, @accentColour);
+    }
+
     #mastodon(@lookup, @accent) {
         @catppuccin: {
             @latte: {
@@ -168,14 +172,14 @@ domain("mastodon.social") {
         @mantle: @catppuccin[@@lookup][@mantle];
         @crust: @catppuccin[@@lookup][@crust];
         @accent-colour: @catppuccin[@@lookup][@@accent];
-    
+
         body,
         .tabs-bar__wrapper,
         .admin-wrapper .sidebar-wrapper__inner {
             background: @crust;
             color: @text;
         }
-        
+
         .account__header__bio .account__header__fields dt {
             background: transparent;
         }

--- a/dist/catppuccin.user.css
+++ b/dist/catppuccin.user.css
@@ -16,13 +16,25 @@ domain("fosstodon.org"),
 domain("tech.lgbt"),
 domain("mastodon.social") {
 
+    :root:has(.theme-mastodon-light) {
+        #mastodon(@lightFlavour, @accentColour);
+    }
 
-    .theme-default {
+    :root:has(.theme-default) {
         #mastodon(@darkFlavour, @accentColour);
     }
 
+    :root:has(.theme-contrast) {
+        #mastodon(@darkFlavour, @accentColour);
+    }
+
+
     .theme-mastodon-light {
         #mastodon(@lightFlavour, @accentColour);
+    }
+
+    .theme-default {
+        #mastodon(@darkFlavour, @accentColour);
     }
 
     .theme-contrast {
@@ -596,3 +608,4 @@ domain("mastodon.social") {
         }
     }
 }
+


### PR DESCRIPTION
I think the CSS selector ":root:has(<theme>)" is not really necessary and only breaks things (which was my case). This PR also fixes the light and contrast themes.